### PR TITLE
Added in Redis kickstart stuff

### DIFF
--- a/scripts/files/elements/ubuntu-redis/README.md
+++ b/scripts/files/elements/ubuntu-redis/README.md
@@ -1,0 +1,1 @@
+Sets up a redis server install in the image.

--- a/scripts/files/elements/ubuntu-redis/install.d/10-redis
+++ b/scripts/files/elements/ubuntu-redis/install.d/10-redis
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# CONTEXT: GUEST during CONSTRUCTION as ROOT
+# PURPOSE: Install controller base required packages
+
+set -ex
+
+export DEBIAN_FRONTEND=noninteractive
+add-apt-repository ppa:rwky/redis -y
+apt-get update
+apt-get install -y redis-server

--- a/scripts/functions_qemu
+++ b/scripts/functions_qemu
@@ -47,7 +47,7 @@ function cmd_build_image() {
     fi
     SERVICE_TYPE=$1
 
-    VALID_SERVICES='mysql percona'
+    VALID_SERVICES='mysql percona redis'
     if [ `expr  "$VALID_SERVICES" : ".*$SERVICE"` -eq 0 ] ; then
         exclaim "You did not pass in a valid image type. Valid types are:" $VALID_SERVICES
         exit 1


### PR DESCRIPTION
blueprint: redis-base-image

blueprint ref: https://blueprints.launchpad.net/trove-integration/+spec/redis-base-image

Added a install.d jobs for installing redis for redstack kickstart.
