### PR TITLE
update to Couchbase Server CE 3.0.1

### DIFF
--- a/scripts/files/elements/ubuntu-couchbase/install.d/10-couchbase
+++ b/scripts/files/elements/ubuntu-couchbase/install.d/10-couchbase
@@ -4,5 +4,5 @@ set -o xtrace
 export DEBIAN_FRONTEND=noninteractive
 apt-get install -qy curl
 apt-get install -qy libssl0.9.8
-curl -O http://packages.couchbase.com/releases/2.2.0/couchbase-server-community_2.2.0_x86_64.deb
-INSTALL_DONT_START_SERVER=1 dpkg -i couchbase-server-community_2.2.0_x86_64.deb
+curl -O http://packages.couchbase.com/releases/3.0.1/couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb
+INSTALL_DONT_START_SERVER=1 dpkg -i couchbase-server-community_3.0.1-ubuntu12.04_amd64.deb

--- a/scripts/redstack
+++ b/scripts/redstack
@@ -496,7 +496,7 @@ function cmd_set_datastore() {
         VERSION="2.1.0"
     elif [ "$DATASTORE_TYPE" == "couchbase" ]; then
         PACKAGES=${PACKAGES:-"couchbase-server"}
-        VERSION="2.2.0"
+        VERSION="3.0.1"
     elif [ "$DATASTORE_TYPE" == "postgresql" ]; then
         PACKAGES=${PACKAGES:-"postgresql-9.3"}
         VERSION="9.3"


### PR DESCRIPTION
This updates the OpenStack Trove to the latest release of Couchbase Server Community Edition.