### PR TITLE
remove 'exit 0' in redstact at line 11

### DIFF
--- a/scripts/redstack
+++ b/scripts/redstack
@@ -8,7 +8,6 @@
 # test.                                                                       #
 #                                                                             #
 ###############################################################################
-exit 0
 
 REDSTACK_SCRIPTS=${REDSTACK_SCRIPTS:-`pwd`}
 REDSTACK_TESTS=$REDSTACK_SCRIPTS/../tests/


### PR DESCRIPTION
I fork the latest code and when I run "./redstack install ", nothing happend.
Then I find there is a 'exit 0' at line 11 in redstack script 