### PR TITLE
Encapsulate some args passed to package managers

### DIFF
--- a/scripts/redstack
+++ b/scripts/redstack
@@ -160,12 +160,14 @@ function set_trove_plugin_vars () {
 
 function pkg_install () {
     echo Installing $@...
-    sudo -E DEBIAN_FRONTEND=noninteractive $HTTP_PROXY $PKG_MGR $PKG_GET_ARGS install $@
+     apt-get update && sudo -E DEBIAN_FRONTEND=noninteractive $HTTP_PROXY $PKG_MGR $PKG_GET_ARGS install $@
+     yum check-update
 }
 
 function pkg_update () {
     echo Updating $@...
-    sudo -E DEBIAN_FRONTEND=noninteractive $HTTP_PROXY $PKG_MGR $PKG_GET_ARGS update $@
+    apt-get install -y -q package &&  sudo -E DEBIAN_FRONTEND=noninteractive $HTTP_PROXY $PKG_MGR $PKG_GET_ARGS update $@
+    yum check-update
 }
 
 function set_home_dir() {


### PR DESCRIPTION
With the refresh of Fedora support in redstack, there are a couple of places in the code that have benign but incorrect args passed to yum as the $PKG_MGR.

sudo -E DEBIAN_FRONTEND=noninteractive $HTTP_PROXY $PKG_MGR $PKG_GET_ARGS install $@

"DEBIAN_FRONTEND=noninteractive" is meaningless to yum and should be encapsulated for clarity.

Change-Id: If7134a5750fe26872cb1ef12db2fe0ec7f8cdf29
Closes-bug: bug/1492484